### PR TITLE
Fix quotation save error

### DIFF
--- a/app/api/quotations/route.ts
+++ b/app/api/quotations/route.ts
@@ -300,6 +300,26 @@ export async function POST(request: Request) {
     }, { status: 401 })
   }
 
+  // Asegurar que el usuario de la sesión exista en la base de datos antes de crear la cotización
+  try {
+    const existingDbUser = await prisma.user.findUnique({ where: { id: session.user.id } })
+    if (!existingDbUser) {
+      console.log('DB user not found. Creating user record for session user:', session.user.id)
+      await prisma.user.create({
+        data: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          password: user.password,
+          role: user.role as any,
+        }
+      })
+    }
+  } catch (userEnsureError) {
+    console.error('Error ensuring DB user exists:', userEnsureError)
+    return NextResponse.json({ error: "Failed to ensure user exists in database" }, { status: 500 })
+  }
+
   try {
     const body = await request.json()
     console.log('Raw request body:', body);


### PR DESCRIPTION
Ensures the session user exists in the database before saving a quotation to prevent 500 errors due to foreign key constraints.

The previous implementation could lead to a 500 Internal Server Error when attempting to save a quotation if the authenticated user (from the session) did not have a corresponding record in the `User` table, resulting in a foreign key constraint violation during the `Quotation` creation. This change checks for the user's existence and creates the record if it's missing, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-aab025b2-6e57-49a8-b134-61eea9386119">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aab025b2-6e57-49a8-b134-61eea9386119">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

